### PR TITLE
Add subquery condition

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -59,6 +59,10 @@ module PgSearch
       options[:ranked_by]
     end
 
+    def subquery_condition
+      options[:subquery_condition]
+    end
+
     def features
       Array(options[:using])
     end
@@ -84,7 +88,7 @@ module PgSearch
     end
 
     VALID_KEYS = %w[
-      against ranked_by ignoring using query associated_against order_within_rank
+      against ranked_by ignoring using query associated_against order_within_rank subquery_condition
     ].map(&:to_sym)
 
     VALID_VALUES = {

--- a/lib/pg_search/model.rb
+++ b/lib/pg_search/model.rb
@@ -15,7 +15,14 @@ module PgSearch
                        end
 
         define_singleton_method(name) do |*args|
-          config = Configuration.new(options_proc.call(*args), self)
+          custom_options = {}
+          if args.first.kind_of?(Array)
+            custom_options = options_proc.call(args[0][0])
+            custom_options = custom_options.merge(args[0][1])
+          else
+            custom_options = options_proc.call(*args)
+          end
+          config = Configuration.new(custom_options, self)
           scope_options = ScopeOptions.new(config)
           scope_options.apply(self)
         end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -88,6 +88,7 @@ module PgSearch
         .select("#{rank} AS rank")
         .joins(subquery_join)
         .where(conditions)
+        .where(config.subquery_condition)
         .limit(nil)
         .offset(nil)
     end


### PR DESCRIPTION
Enable passing where conditions inside subquery where calculating ranks for search query. Because order by operation is expensive on this way we doing sorting on smaller number of rows.

To pass params to subquery we must past subquery_condition hash, something like this.

` GlobalSearchData.full_text_search([query.downcase,
      subquery_condition: {
        order_sample_laboratory_id: laboratory.id,
        order_sample_account_id: laboratory.account_id,
        order_sample_aasm_state: authorized_states}
    ]).limit(50)`